### PR TITLE
adjust max bytes per event

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -224,7 +224,7 @@ func (w *Writer) writeEventContext(ctx context.Context, now time.Time, message s
 	})
 	w.currentByteLength += l
 	if len(w.events) == maximumLogEventsPerPut || // the count of events reaches the limit
-		w.currentByteLength >= maximumBytesPerEvent { // byte length reaches the limit
+		w.currentByteLength >= maximumBytesPerPut { // byte length reaches the limit
 
 		// we need to flush
 		if err := w.FlushContext(ctx); err != nil {

--- a/writer.go
+++ b/writer.go
@@ -21,7 +21,7 @@ const (
 	perEventBytes          = 26
 	maximumBytesPerPut     = 1048576
 	maximumLogEventsPerPut = 10000
-	maximumBytesPerEvent   = maximumBytesPerPut - perEventBytes
+	maximumBytesPerEvent   = 262144 - perEventBytes
 )
 
 // Writer is a wrapper CloudWatch Logs that provides io.Writer interface.

--- a/writer_test.go
+++ b/writer_test.go
@@ -87,13 +87,13 @@ func TestWriter_Write_LongLongLine(t *testing.T) {
 	}
 
 	// "あ" has 3 bytes (len("あ") = 3)
-	// and PutLogEvents can put an event up to 1048550 bytes at a time.
-	// (1048550 bytes = maximumBytesPerPut-perEventBytes)
+	// and PutLogEvents can put an event up to 262118 bytes at a time.
+	// (262118 bytes = maximumBytesPerEvent)
 	//
-	// WriteEvent separates the message that has more than 349516 あ.
-	// len("あ") x 349516 = 1048548 bytes < 1048550 bytes
-	// len("あ") x 349517 = 1048551 bytes > 1048550 bytes
-	for i := 0; i < 349517; i++ {
+	// WriteEvent separates the message that has more than 87372 あ.
+	// len("あ") x 87372 = 262116 bytes < 262118 bytes
+	// len("あ") x 87373 = 262119 bytes > 262118 bytes
+	for i := 0; i < 87373; i++ {
 		n, err := w.Write([]byte("あ"))
 		if err != nil {
 			t.Fatal(err)
@@ -109,7 +109,7 @@ func TestWriter_Write_LongLongLine(t *testing.T) {
 		t.Errorf("unexpected events count: %d", len(events))
 	}
 
-	want := strings.Repeat("あ", 349516)
+	want := strings.Repeat("あ", 87372)
 	if events[0] != want {
 		t.Errorf("unexpected event: %s", events[0])
 	}
@@ -148,7 +148,7 @@ func TestWriter_WriteString(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(output, events); diff != "" {
-		t.Errorf("unexpected evenets (-want/+got):\n%s", diff)
+		t.Errorf("unexpected events (-want/+got):\n%s", diff)
 	}
 }
 
@@ -169,13 +169,13 @@ func TestWriter_WriteString_LongLongLine(t *testing.T) {
 	}
 
 	// "あ" has 3 bytes (len("あ") = 3)
-	// and PutLogEvents can put an event up to 1048550 bytes at a time.
-	// (1048550 bytes = maximumBytesPerPut-perEventBytes)
+	// and PutLogEvents can put an event up to 262118 bytes at a time.
+	// (262118 bytes = maximumBytesPerEvent)
 	//
-	// WriteEvent separates the message that has more than 349516 あ.
-	// len("あ") x 349516 = 1048548 bytes < 1048550 bytes
-	// len("あ") x 349517 = 1048551 bytes > 1048550 bytes
-	for i := 0; i < 349517; i++ {
+	// WriteEvent separates the message that has more than 87372 あ.
+	// len("あ") x 87372 = 262116 bytes < 262118 bytes
+	// len("あ") x 87373 = 262119 bytes > 262118 bytes
+	for i := 0; i < 87373; i++ {
 		n, err := w.WriteString("あ")
 		if err != nil {
 			t.Fatal(err)
@@ -191,7 +191,7 @@ func TestWriter_WriteString_LongLongLine(t *testing.T) {
 		t.Errorf("unexpected events count: %d", len(events))
 	}
 
-	want := strings.Repeat("あ", 349516)
+	want := strings.Repeat("あ", 87372)
 	if events[0] != want {
 		t.Errorf("unexpected event: %s", events[0])
 	}

--- a/writer_test.go
+++ b/writer_test.go
@@ -458,13 +458,13 @@ func TestWriter_WriteEventContext_LongLongLine(t *testing.T) {
 	}
 
 	// "あ" has 3 bytes (len("あ") = 3)
-	// and PutLogEvents can put an event up to 1048550 bytes at a time.
-	// (1048550 bytes = maximumBytesPerPut-perEventBytes)
+	// and PutLogEvents can put an event up to 262118 bytes at a time.
+	// (262118 bytes = maximumBytesPerEvent)
 	//
-	// WriteEvent separates the message that has more than 349516 あ.
-	// len("あ") x 349516 = 1048548 bytes < 1048550 bytes
-	// len("あ") x 349517 = 1048551 bytes > 1048550 bytes
-	line := strings.Repeat("あ", 349517)
+	// WriteEvent separates the message that has more than 87372 あ.
+	// len("あ") x 87372 = 262116 bytes < 262118 bytes
+	// len("あ") x 87373 = 262119 bytes > 262118 bytes
+	line := strings.Repeat("あ", 87373)
 
 	n, err := w.WriteEvent(time.Now(), line)
 	if err != nil {
@@ -480,7 +480,7 @@ func TestWriter_WriteEventContext_LongLongLine(t *testing.T) {
 	if len(events) != 2 {
 		t.Errorf("unexpected events count: %d", len(events))
 	}
-	want := strings.Repeat("あ", 349516)
+	want := strings.Repeat("あ", 87372)
 	if events[0] != want {
 		t.Errorf("unexpected event: %s", events[0])
 	}
@@ -508,13 +508,13 @@ func TestWriter_WriteEventContext_ReplacementChar(t *testing.T) {
 	// "\x80" has 1 bytes (len("\x80") = 1),
 	// however it is replaced by U+FFFD � replacement character,
 	// and U+FFFD has 3 bytes (len("\uFFFD") = 3).
-	// and PutLogEvents can put an event up to 1048550 bytes at a time.
-	// (1048550 bytes = maximumBytesPerPut-perEventBytes)
+	// and PutLogEvents can put an event up to 262118 bytes at a time.
+	// (262118 bytes = maximumBytesPerEvent)
 	//
-	// WriteEvent separates the message that has more than 349516 "\x80".
-	// len("\uFFFD") x 349516 = 1048548 bytes < 1048550 bytes
-	// len("\uFFFD") x 349517 = 1048551 bytes > 1048550 bytes
-	line := strings.Repeat("\x80", 349517)
+	// WriteEvent separates the message that has more than 87373 "\x80".
+	// len("\uFFFD") x 87372 = 262116 bytes < 262118 bytes
+	// len("\uFFFD") x 87373 = 262119 bytes > 262118 bytes
+	line := strings.Repeat("\x80", 87373)
 
 	n, err := w.WriteEvent(time.Now(), line)
 	if err != nil {
@@ -528,7 +528,7 @@ func TestWriter_WriteEventContext_ReplacementChar(t *testing.T) {
 	if len(events) != 2 {
 		t.Errorf("unexpected events count: %d", len(events))
 	}
-	want := strings.Repeat("\uFFFD", 349516)
+	want := strings.Repeat("\uFFFD", 87372)
 	if events[0] != want {
 		t.Errorf("unexpected event: %s", events[0])
 	}


### PR DESCRIPTION
2022/11/10 06:24:56.551425 [ERROR] writing logs failed: operation error CloudWatch Logs: PutLogEvents, https response error StatusCode: 400, RequestID: 4e858ff7-7d8e-4113-9bef-5b149c1585b9, InvalidParameterException: Log event too large: 1048574 bytes exceeds limit of 262144