### PR TITLE
drop support of CentOS 8

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -95,14 +95,6 @@ blobs:
   - provider: s3
     bucket: shogo82148-rpm-temporary
     ids: [package-amd64]
-    folder: centos/8/x86_64/cloudwatch-logs-agent-lite
-  - provider: s3
-    bucket: shogo82148-rpm-temporary
-    ids: [package-arm64]
-    folder: centos/8/aarch64/cloudwatch-logs-agent-lite
-  - provider: s3
-    bucket: shogo82148-rpm-temporary
-    ids: [package-amd64]
     folder: almalinux/8/x86_64/cloudwatch-logs-agent-lite
   - provider: s3
     bucket: shogo82148-rpm-temporary


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated release configurations, removing support for specific CentOS 8 architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->