### PR TITLE
bump goreleaser v2

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Check GoReleaser configure
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
+          version: "~> v2"
           args: check

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 # This is an example .goreleaser.yml file with some sane defaults.
 # Make sure to check the documentation at http://goreleaser.com
+version: 2
 before:
   hooks:
     - go mod download


### PR DESCRIPTION
goreleaser v2 has been released.

- https://goreleaser.com/blog/goreleaser-v2/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded `goreleaser/goreleaser-action` action to version `v6` in GitHub workflows.
  - Updated version specification for GoReleaser configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->