### PR TITLE
fix: DEPRECATED:  snapshot.name_template  should not be used anymore

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,7 +38,7 @@ archives:
 checksum:
   name_template: "checksums.txt"
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated release configuration to modify how snapshot versions are generated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->