### PR TITLE
Fix goreleaser warnings

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,7 +32,7 @@ builds:
       - -s -w
       - -X main.version={{.Version}}
 archives:
-  - builds:
+  - ids:
       - cli-amd64
       - cli-arm64
 checksum:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,7 +48,7 @@ changelog:
 
 nfpms:
   - id: package-amd64
-    builds:
+    ids:
       - cli-amd64
     homepage: https://github.com/shogo82148/cloudwatch-logs-agent-lite/
     maintainer: ICHINOSE Shogo <shogo82148@gmail.com>
@@ -62,7 +62,7 @@ nfpms:
     epoch: 0
     bindir: /usr/bin
   - id: package-arm64
-    builds:
+    ids:
       - cli-arm64
     homepage: https://github.com/shogo82148/cloudwatch-logs-agent-lite/
     maintainer: ICHINOSE Shogo <shogo82148@gmail.com>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated release packaging configuration to align with the latest GoReleaser schema, switching archives and packages to reference artifact IDs via “ids” instead of “builds.”
  - Artifact names and supported architectures remain unchanged (amd64, arm64), ensuring consistent binary and package generation.
  - No changes to app features, behavior, or documentation; end users should see no differences beyond continued availability of binaries/packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->