### PR TITLE
migrate to fuller-inc/actions-aws-assume-role

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Configure AWS Credentials
-        uses: shogo82148/actions-aws-assume-role@ab8b68ccaa6a83d843cd6f9403fc3c0eb2e3af0c # v1.7.1
+        uses: fuller-inc/actions-aws-assume-role@ab8b68ccaa6a83d843cd6f9403fc3c0eb2e3af0c # v1.7.1
         with:
           aws-region: ap-northeast-1
           role-to-assume: arn:aws:iam::445285296882:role/rpm-repository-users-CloudWatchLogsAgentRole-19MYK77MOJY8B


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release pipeline to use a new AWS role-assumption action for configuring credentials, preserving the same inputs and behavior.
  * Improves pipeline reliability and maintainability with no impact on application functionality or user experience.
  * No changes to exported/public APIs.
  * No changes to release process outputs; deployments continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->