### PR TITLE
bump Go 1.25.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/shogo82148/cloudwatch-logs-agent-lite
 
-go 1.25.0
+go 1.25.1
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.38.3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Go toolchain to 1.25.1 in project configuration to align with the latest patch release. This ensures improved stability, compatibility, and access to upstream fixes in development and CI builds. No changes to dependencies, APIs, or runtime behavior. No action required for end users; application functionality remains unchanged. Release footprint is maintenance-only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->