### PR TITLE
fix releasing config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,12 +39,13 @@ checksum:
   name_template: "checksums.txt"
 snapshot:
   version_template: "{{ .Tag }}-next"
+
+# https://songmu.jp/riji/entry/2025-09-05-coordinate-tagpr-and-goreleaser-with-immutable-releases.html
+release:
+  use_existing_draft: true
+
 changelog:
-  sort: asc
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"
+  use: github-native
 
 nfpms:
   - id: package-amd64

--- a/.tagpr
+++ b/.tagpr
@@ -49,3 +49,4 @@
 	vPrefix = true
 	releaseBranch = main
 	versionFile = -
+	release = draft # https://songmu.jp/riji/entry/2025-09-05-coordinate-tagpr-and-goreleaser-with-immutable-releases.html


### PR DESCRIPTION
ref. https://songmu.jp/riji/entry/2025-09-05-coordinate-tagpr-and-goreleaser-with-immutable-releases.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated release process to reuse existing draft releases.
  - Switched changelog generation to GitHub-native for release notes.
  - New tags now automatically create draft releases for review before publishing.
  - No changes to application features or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->