### PR TITLE
drop support of Amazon Linux 2 and CentOS 7

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -78,16 +78,6 @@ nfpms:
     bindir: /usr/bin
 
 blobs:
-  # Amazon Linux 2
-  - provider: s3
-    bucket: shogo82148-rpm-temporary
-    ids: [package-amd64]
-    directory: amazonlinux/2/x86_64/cloudwatch-logs-agent-lite
-  - provider: s3
-    bucket: shogo82148-rpm-temporary
-    ids: [package-arm64]
-    directory: amazonlinux/2/aarch64/cloudwatch-logs-agent-lite
-
   # Amazon Linux 2023
   - provider: s3
     bucket: shogo82148-rpm-temporary
@@ -97,16 +87,6 @@ blobs:
     bucket: shogo82148-rpm-temporary
     ids: [package-arm64]
     directory: amazonlinux/2023/aarch64/cloudwatch-logs-agent-lite
-
-  # CentOS 7
-  - provider: s3
-    bucket: shogo82148-rpm-temporary
-    ids: [package-amd64]
-    directory: centos/7/x86_64/cloudwatch-logs-agent-lite
-  - provider: s3
-    bucket: shogo82148-rpm-temporary
-    ids: [package-arm64]
-    directory: centos/7/aarch64/cloudwatch-logs-agent-lite
 
   # AlmaLinux 8
   - provider: s3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed automated build and publication of packages for Amazon Linux 2 and CentOS 7 platforms (both x86_64 and arm64 architectures).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->